### PR TITLE
ソースごと測定値のページで、水位しかないソースの場合に「水位流量」と表示していたのを「水位」に修正

### DIFF
--- a/application/views/values/water_level.php
+++ b/application/views/values/water_level.php
@@ -1,4 +1,4 @@
 <?php
 $value_type = 'water_level';
-$value_type_name = '水位流量';
+$value_type_name = '水位';
 include('single_value.php');


### PR DESCRIPTION
close #15