### PR TITLE
岐阜の水位データについて24時間以上前のデータの測定時刻の計算を誤って、24時間以内のデータを上書きしてしまっていたのを修正。

### DIFF
--- a/application/models/MeasuredSources/Gifu/GifuCollector.php
+++ b/application/models/MeasuredSources/Gifu/GifuCollector.php
@@ -58,9 +58,10 @@ namespace MeasuredSources\Gifu {
         private function extract($content, $acquired_at)
         {
             $datum = array();
+            $current = $acquired_at;
             foreach (explode("\n", $content) as $line) {
                 if (preg_match('/(\d{1,2}:\d{2})\s+(-?\d+(?:\.\d+)?)/', $line, $matches)) {
-                    $measured_at = $this->measured_date_normalizer->normalize_time($matches[1]);
+                    $measured_at = $this->measured_date_normalizer->normalize_time_backword($matches[1], $current);
                     if ($measured_at === null) {
                         continue;
                     }
@@ -72,6 +73,7 @@ namespace MeasuredSources\Gifu {
                         'flags' => isset($value) ? \Entities\MeasuredValueFlags::NONE : \Entities\MeasuredValueFlags::MISSED,
                         'acquired_at' => $acquired_at,
                     );
+                    $current = $measured_at;
                 }
             }
             return $datum;

--- a/application/models/MeasuredSources/Kyoto/KyotoCollector.php
+++ b/application/models/MeasuredSources/Kyoto/KyotoCollector.php
@@ -50,10 +50,11 @@ namespace MeasuredSources\Kyoto {
             $element = $hrs->item(4);
             $buff = '';
             $datum = array();
+            $current = $date;
             while (null != ($element = $element->nextSibling)) {
                 $buff .= $this->entity_space_replacer->replace($element->textContent);
                 if (preg_match('/\b(\d{1,2}:\d{2})\b\s+(\d+(?:\.\d+)?)m/', $buff, $matches)) {
-                    $measured_at = $this->measured_date_normalizer->normalize_time($matches[1]);
+                    $measured_at = $this->measured_date_normalizer->normalize_time_backword($matches[1], $current);
                     if ($measured_at === null) {
                         continue;
                     }
@@ -69,6 +70,7 @@ namespace MeasuredSources\Kyoto {
                         'acquired_at' => $date,
                     );
                     $buff = '';
+                    $current = $measured_at;
                 }
             }
             return $datum;

--- a/application/models/MeasuredSources/Wakayama/WakayamaCollector.php
+++ b/application/models/MeasuredSources/Wakayama/WakayamaCollector.php
@@ -72,12 +72,14 @@ namespace MeasuredSources\Wakayama {
             $normalizer = new \MeasuredSources\MeasuredDateNormalizer();
             $datum = array();
             $value_type = $this->value_type_provider->get();
+            $date = $acquired_at;
             foreach (explode("\n", $content) as $line) {
                 if (preg_match('/(\d{1,2}:\d{2})\s+(\S+)/', $line, $matches)) {
-                    $measured_at = $normalizer->normalize_time($matches[1]);
+                    $measured_at = $normalizer->normalize_time_backword($matches[1], $date);
                     if ($measured_at === null) {
                         continue;
                     }
+                    $date = $measured_at;
                     $value = is_numeric($matches[2]) ? $matches[2] - 0 : null;
                     $datum[] = array(
                         'measured_at' => $measured_at,


### PR DESCRIPTION
close #8 