### PR TITLE
国土交通省のダムのソースごと測定値一覧で、有効な測定値が全くない項目がある場合に正常にページが表示できなかった問題を修正。

### DIFF
--- a/application/views/values/mlitt_dam.php
+++ b/application/views/values/mlitt_dam.php
@@ -29,6 +29,7 @@ foreach (array_reverse($measured_data) as $row) {
             $flags_key = "{$field}_flags";
             $diff_key = "{$field}_diff";
             $array[$diff_key] = 0;
+            $difference = 0;
             if (is_measured_value_enable($row[$value_key], $row[$flags_key])) {
                 if (is_measured_value_enable($last[$value_key], $last[$flags_key])) {
                     $difference = $row[$value_key] - $last[$value_key];


### PR DESCRIPTION
close #34 